### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ task.arguments = @[ @"-k", _testURL.stringValue ];
 // ... then do what you will with the results ... //
 
 ```
-if not using cocoa pods, make sure to include `-ObjC` in you build setting's other linker flags so the category isn't optimized out.
+if not using CocoaPods, make sure to include `-ObjC` in you build setting's other linker flags so the category isn't optimized out.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
