### PR TITLE
Check that response is of NS*HTTP*URLResponse

### DIFF
--- a/AHProxySettings/AHProxySettings.m
+++ b/AHProxySettings/AHProxySettings.m
@@ -107,7 +107,7 @@ NSString *const kNSProxyHTTPS;
                                           returningResponse:&resp
                                                       error:&error];
 
-                if (reqData && resp.statusCode < 400) {
+                if (reqData && (![resp respondsToSelector:@selector(statusCode)] || resp.statusCode < 400)) {
                     _pacFunction =
                         [[NSString alloc] initWithData:reqData
                                               encoding:NSASCIIStringEncoding];


### PR DESCRIPTION
Fixes a crash that was seen in BitBar: https://github.com/matryer/bitbar/issues/246
